### PR TITLE
mod StackOverflow Error

### DIFF
--- a/ncmb-core/src/main/java/com/nifcloud/mbaas/core/NCMB.java
+++ b/ncmb-core/src/main/java/com/nifcloud/mbaas/core/NCMB.java
@@ -260,7 +260,7 @@ public class NCMB {
     public static NCMBContext getCurrentContext() {
         if (sCurrentContext == null) {
             Context context = NCMBApplicationController.getApplicationState();
-            if (!getApplicationKey().isEmpty() && !getClientKey().isEmpty() && !getApiBaseUrl().isEmpty() && context == null) {
+            if (null == context) {
                 throw new IllegalArgumentException("Please call the NCMB.initialize() method.");
             }
 

--- a/ncmb-core/src/main/java/com/nifcloud/mbaas/core/NCMB.java
+++ b/ncmb-core/src/main/java/com/nifcloud/mbaas/core/NCMB.java
@@ -260,8 +260,8 @@ public class NCMB {
     public static NCMBContext getCurrentContext() {
         if (sCurrentContext == null) {
             Context context = NCMBApplicationController.getApplicationState();
-            if (null == context) {
-                throw new IllegalArgumentException("Please call the NCMB.initialize() method.");
+            if (context == null) {
+                throw new RuntimeException("Please call the NCMB.initialize() method.");
             }
 
             // staticが破棄(プロセスの終了やGCによる解放など)された後にinitializeメソッドが実行されていない場合は永続化したデータを元に再生成

--- a/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
+++ b/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
@@ -143,4 +143,42 @@ public class NCMBTest {
         NCMB.enableResponseValidation(true);
         Assert.assertEquals(true, preferences.getBoolean("responseValidation", false));
     }
+
+    @Test
+    public void checkContextAndContextImplNull() {
+
+        IllegalArgumentException error = null;
+        try {
+            //初期化
+            NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(), "applicationKey", "clientKey");
+
+            // Context = null設定
+            // GCがstaticを解放した場合やプロセスが破棄された場合をモック(sCurrentContextがnullになる)
+            Field modifiersField = null;
+            modifiersField = NCMB.class.getDeclaredField("sCurrentContext");
+            modifiersField.setAccessible(true);
+            modifiersField.set(null, null);// モックの戻り値
+
+            // ContextImpl = null設定
+            Field modifiersField2 = null;
+            modifiersField2 = NCMBApplicationController.class.getDeclaredField("sApplicationState");
+            modifiersField2.setAccessible(true);
+            modifiersField2.set(null, null);// モックの戻り値
+
+            // 両方 =Null場合　IllegalArgumentException発生する
+            NCMBContext testContext = NCMB.getCurrentContext();
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail(e.getMessage());
+        } catch (IllegalAccessException e) {
+            Assert.fail(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            error = e;
+            Assert.assertEquals("Please call the NCMB.initialize() method.", e.getMessage());
+        }
+
+        //check
+        Assert.assertNotNull(error);
+    }
+
 }

--- a/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
+++ b/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
@@ -147,7 +147,7 @@ public class NCMBTest {
     @Test
     public void checkContextAndContextImplNull() {
 
-        IllegalArgumentException error = null;
+        RuntimeException error = null;
         try {
             //初期化
             NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(), "applicationKey", "clientKey");
@@ -172,7 +172,7 @@ public class NCMBTest {
             Assert.fail(e.getMessage());
         } catch (IllegalAccessException e) {
             Assert.fail(e.getMessage());
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             error = e;
             Assert.assertEquals("Please call the NCMB.initialize() method.", e.getMessage());
         }
@@ -183,7 +183,7 @@ public class NCMBTest {
 
         try {
             NCMBUser user = NCMBUser.getCurrentUser();
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             error = e;
             Assert.assertEquals("Please call the NCMB.initialize() method.", e.getMessage());
         }
@@ -192,7 +192,7 @@ public class NCMBTest {
 
         try {
             NCMBInstallation installation = NCMBInstallation.getCurrentInstallation();
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             error = e;
             Assert.assertEquals("Please call the NCMB.initialize() method.", e.getMessage());
         }
@@ -202,7 +202,7 @@ public class NCMBTest {
     @Test
     public void checkContextAndContextImplNullCanBeReproducedByInitialize() {
 
-        IllegalArgumentException error = null;
+        RuntimeException error = null;
         try {
             //初期化
             NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(), "applicationKey", "clientKey");
@@ -230,7 +230,7 @@ public class NCMBTest {
             Assert.fail(e.getMessage());
         } catch (IllegalAccessException e) {
             Assert.fail(e.getMessage());
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             error = e;
         }
 

--- a/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
+++ b/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
@@ -222,8 +222,9 @@ public class NCMBTest {
 
             NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(), "applicationKey", "clientKey");
 
-            // 両方 =Null場合　IllegalArgumentException発生する
             NCMBContext testContext = NCMB.getCurrentContext();
+            //check
+            Assert.assertNotNull(testContext);
 
         } catch (NoSuchFieldException e) {
             Assert.fail(e.getMessage());

--- a/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
+++ b/ncmb-core/src/test/java/com/nifcloud/mbaas/core/NCMBTest.java
@@ -179,6 +179,62 @@ public class NCMBTest {
 
         //check
         Assert.assertNotNull(error);
+        error = null;
+
+        try {
+            NCMBUser user = NCMBUser.getCurrentUser();
+        } catch (IllegalArgumentException e) {
+            error = e;
+            Assert.assertEquals("Please call the NCMB.initialize() method.", e.getMessage());
+        }
+        Assert.assertNotNull(error);
+        error = null;
+
+        try {
+            NCMBInstallation installation = NCMBInstallation.getCurrentInstallation();
+        } catch (IllegalArgumentException e) {
+            error = e;
+            Assert.assertEquals("Please call the NCMB.initialize() method.", e.getMessage());
+        }
+        Assert.assertNotNull(error);
+    }
+
+    @Test
+    public void checkContextAndContextImplNullCanBeReproducedByInitialize() {
+
+        IllegalArgumentException error = null;
+        try {
+            //初期化
+            NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(), "applicationKey", "clientKey");
+
+            // Context = null設定
+            // GCがstaticを解放した場合やプロセスが破棄された場合をモック(sCurrentContextがnullになる)
+            Field modifiersField = null;
+            modifiersField = NCMB.class.getDeclaredField("sCurrentContext");
+            modifiersField.setAccessible(true);
+            modifiersField.set(null, null);// モックの戻り値
+
+            // ContextImpl = null設定
+            Field modifiersField2 = null;
+            modifiersField2 = NCMBApplicationController.class.getDeclaredField("sApplicationState");
+            modifiersField2.setAccessible(true);
+            modifiersField2.set(null, null);// モックの戻り値
+
+            NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(), "applicationKey", "clientKey");
+
+            // 両方 =Null場合　IllegalArgumentException発生する
+            NCMBContext testContext = NCMB.getCurrentContext();
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail(e.getMessage());
+        } catch (IllegalAccessException e) {
+            Assert.fail(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            error = e;
+        }
+
+        //check
+        Assert.assertNull(error);
     }
 
 }


### PR DESCRIPTION
## 概要(Summary)
- Fixed #84 
  
  ・ NCMBUser.getCurrentUserを呼び出した際にStackOverflowErrorが発生する問題を修正
  ・staticが破棄後、Activityコンテキスト、ContextImplオブジェクト両方がnullになった場合、元の呼び出しを呼ぶので無限ループ処理になるのが原因です。
## 動作確認手順(Step for Confirmation)

Run the Android.
