### PR TITLE
NCMBServicePool の作りの対応

### DIFF
--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMB.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMB.java
@@ -100,6 +100,11 @@ public class NCMB {
     private static boolean sResponseValidation;
 
     /**
+     * service pool
+     */
+    protected static NCMBServicePool sServicePool;
+
+    /**
      * Setup SDK internals
      *
      * @param context        Application context
@@ -144,6 +149,7 @@ public class NCMB {
 
         String apiBaseUrl = aDomainUrl + aApiVersion + "/";
         sCurrentContext = new NCMBContext(context, applicationKey, clientKey, apiBaseUrl);
+        sServicePool = new NCMBServicePool();
 
         // 永続化
         Context appState = NCMBApplicationController.getApplicationState();
@@ -168,34 +174,7 @@ public class NCMB {
      * @return Object of each service class
      */
     public static NCMBService factory(ServiceType serviceType) throws IllegalArgumentException {
-        NCMBService service;
-
-        switch (serviceType) {
-            case OBJECT:
-                service = (NCMBService) new NCMBObjectService(getCurrentContext());
-                break;
-            case USER:
-                service = (NCMBService) new NCMBUserService(getCurrentContext());
-                break;
-            case ROLE:
-                service = (NCMBService) new NCMBRoleService(getCurrentContext());
-                break;
-            case INSTALLATION:
-                service = (NCMBInstallationService) new NCMBInstallationService(getCurrentContext());
-                break;
-            case PUSH:
-                service = (NCMBPushService) new NCMBPushService(getCurrentContext());
-                break;
-            case FILE:
-                service = (NCMBFileService) new NCMBFileService(getCurrentContext());
-                break;
-            case SCRIPT:
-                service = (NCMBScriptService) new NCMBScriptService(getCurrentContext());
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid serviceType");
-        }
-        return service;
+        return sServicePool.get(serviceType, sCurrentContext);
     }
 
     /**

--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBServicePool.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBServicePool.java
@@ -1,0 +1,106 @@
+package com.nifty.cloud.mb.core;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Temporary pool for service object
+ */
+public class NCMBServicePool {
+
+    /** stored services */
+    protected Map<NCMB.ServiceType, HashMap<NCMBContext, NCMBService>> pool;
+
+    /**
+     * Constructor
+     */
+    public NCMBServicePool() {
+        pool = new EnumMap<NCMB.ServiceType, HashMap<NCMBContext, NCMBService>>
+                (NCMB.ServiceType.class);
+    }
+
+    /**
+     * Get service object
+     * @param serviceType service type
+     * @param context context
+     * @return service object
+     */
+    public NCMBService get(NCMB.ServiceType serviceType, NCMBContext context) {
+        NCMBService service;
+        if (exists(serviceType, context)) {
+            service = getServices(serviceType).get(context);
+        } else {
+            service = newService(serviceType, context);
+            getServices(serviceType).put(context, service);
+        }
+        return service;
+    }
+
+    /**
+     * Return service object is already cached
+     * @param serviceType service type
+     * @param context context
+     * @return
+     */
+    public boolean exists(NCMB.ServiceType serviceType, NCMBContext context) {
+        if (!pool.containsKey(serviceType)) {
+            return false;
+        }
+        HashMap<NCMBContext, NCMBService> services = pool.get(serviceType);
+        if (!services.containsKey(context)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get context-keyed hash of given service type
+     * @param serviceType service type
+     * @return
+     */
+    protected HashMap<NCMBContext, NCMBService> getServices(NCMB.ServiceType serviceType) {
+        if (pool.containsKey(serviceType)) {
+            return pool.get(serviceType);
+        }
+        HashMap<NCMBContext, NCMBService> services = new HashMap<NCMBContext, NCMBService>();
+        pool.put(serviceType, services);
+        return services;
+    }
+
+    /**
+     * Create service object and return it
+     * @param serviceType service type
+     * @param context context
+     * @return service object
+     */
+    public NCMBService newService(NCMB.ServiceType serviceType, NCMBContext context) {
+        NCMBService service;
+        switch (serviceType) {
+            case OBJECT:
+                service = (NCMBService)new NCMBObjectService(context);
+                break;
+            case USER:
+                service = (NCMBService)new NCMBUserService(context);
+                break;
+            case ROLE:
+                service = (NCMBService)new NCMBRoleService(context);
+                break;
+            case INSTALLATION:
+                service = (NCMBInstallationService)new NCMBInstallationService(context);
+                break;
+            case PUSH:
+                service = (NCMBPushService)new NCMBPushService(context);
+                break;
+            case FILE:
+                service = (NCMBFileService) new NCMBFileService(context);
+                break;
+            case SCRIPT:
+                service = (NCMBScriptService) new NCMBScriptService(context);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid serviceType");
+        }
+        return service;
+    }
+}


### PR DESCRIPTION

## 概要(Summary)

同一コンテキストで作成された NCMBService を再利用するように、それを貯める NCMBServicePool を作りました。

## 動作確認手順(Step for Confirmation)

- Run the unit test.
- Confirm memory.

### Confirmation code
```
for (int i = 0; i < 100000; i++) {
   NCMBFileService fileService = (NCMBFileService) NCMB.factory(NCMB.ServiceType.FILE);
   NCMBObjectService objService = (NCMBObjectService) NCMB.factory(NCMB.ServiceType.OBJECT);
   NCMBInstallationService installationService = (NCMBInstallationService) NCMB.factory(NCMB.ServiceType.INSTALLATION);
   NCMBPushService pushService = (NCMBPushService) NCMB.factory(NCMB.ServiceType.PUSH);
   NCMBRoleService roleService = (NCMBRoleService) NCMB.factory(NCMB.ServiceType.ROLE);
   NCMBScriptService scriptService = (NCMBScriptService) NCMB.factory(NCMB.ServiceType.SCRIPT);
   NCMBUserService service = (NCMBUserService) NCMB.factory(NCMB.ServiceType.USER);
}
```
### Memory check result
- Before modification:
![devbranch_before](https://user-images.githubusercontent.com/25733350/38931347-13d4a27e-433d-11e8-8a59-780fc6c88fa9.png)
![devbranch_after](https://user-images.githubusercontent.com/25733350/38931346-139b2526-433d-11e8-8347-864898b09cfc.png)
**=>The memory increased double from 5.5MB to 10.3MB.**

- After modification:
![mergedbranch_before](https://user-images.githubusercontent.com/25733350/38931688-349a7c44-433e-11e8-8f2c-f9bddb692ce4.png)
![mergedbranch_after](https://user-images.githubusercontent.com/25733350/38931722-5a612c2a-433e-11e8-96cc-d1f27ceaac61.png)
**=>The memory just increased a little from 5.6MB to 5.8MB.**
