### PR TITLE
Fix: initial does not end queue

### DIFF
--- a/ncmb-core/src/main/java/com/nifcloud/mbaas/core/NCMBInstallationUtils.java
+++ b/ncmb-core/src/main/java/com/nifcloud/mbaas/core/NCMBInstallationUtils.java
@@ -67,6 +67,8 @@ class NCMBInstallationUtils {
                                 } else if (NCMBException.DATA_NOT_FOUND.equals(saveErr.getCode())) {
                                     //保存失敗 : 端末情報の該当データがない
                                     reRegistInstallation(installation);
+                                } else {
+                                    DeviceTokenCallbackQueue.getInstance().execQueue(token,saveErr);
                                 }
                             }
                         });


### PR DESCRIPTION
## 概要(Summary)

- The NCMB does not response the error and end queue if get error code is "E404005"

## 動作確認手順(Step for Confirmation)

Run the unit test.
