### PR TITLE
Show expandable notification with a big picture from remote Url

### DIFF
--- a/src/main/java/com/nifcloud/mbaas/core/NCMBFirebaseMessagingService.java
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBFirebaseMessagingService.java
@@ -27,10 +27,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 
-import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 
 import android.util.Log;
@@ -59,6 +57,8 @@ public class NCMBFirebaseMessagingService extends FirebaseMessagingService {
     static final String SMALL_ICON_KEY = "smallIcon";
     static final String SMALL_ICON_COLOR_KEY = "smallIconColor";
     static final String NOTIFICATION_OVERLAP_KEY = "notificationOverlap";
+    static final String USER_SETTING_JSON_KEY = "com.nifcloud.mbaas.Data";
+    static final String USER_SETTING_JSON_BIG_PICTURE_URL_KEY = "bigPictureUrlKey";
 
     /**
      * Called if InstanceID token is updated. This may occur if the security of
@@ -231,15 +231,15 @@ public class NCMBFirebaseMessagingService extends FirebaseMessagingService {
 
         //Notification作成
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-        final String dataKey = "com.nifcloud.mbaas.Data";
 
-        if (pushData.getString(dataKey) != null) {
+        if (pushData.getString(USER_SETTING_JSON_KEY) != null) {
             String imageUrl = null;
             Bitmap bitmap = null;
             try {
-                JSONObject userSettingJson = new JSONObject((String) pushData.get(dataKey));
-                if (userSettingJson.get("imgUrl") != null) {
-                    imageUrl = userSettingJson.get("imgUrl").toString();
+                JSONObject userSettingJson = new JSONObject((String) pushData.get(USER_SETTING_JSON_KEY));
+                String bigPictureUrlKey = appInfo.metaData.getString(USER_SETTING_JSON_BIG_PICTURE_URL_KEY);
+                if (userSettingJson.get(bigPictureUrlKey) != null) {
+                    imageUrl = userSettingJson.get(bigPictureUrlKey).toString();
                 }
             } catch (JSONException e) {}
 
@@ -266,6 +266,7 @@ public class NCMBFirebaseMessagingService extends FirebaseMessagingService {
 
         notificationBuilder.setSmallIcon(icon)//通知エリアのアイコン設定
                 .setColor(smallIconColor) //通知エリアのアイコンカラー設定
+                .setLargeIcon(bitmap)
                 .setContentTitle(title)
                 .setContentText(message)
                 .setStyle(bigPictureStyle)

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBFirebaseMessagingService.java
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBFirebaseMessagingService.java
@@ -23,11 +23,18 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
+
 import android.util.Log;
+import android.util.Patterns;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -36,6 +43,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.Map;
 import java.util.Random;
 
@@ -213,13 +224,58 @@ public class NCMBFirebaseMessagingService extends FirebaseMessagingService {
             //それ以外はアプリのアイコンを設定する
             icon = appInfo.icon;
         }
+
+        final NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NCMBNotificationUtils.getDefaultChannel());
         //SmallIconカラーを設定
         int smallIconColor = appInfo.metaData.getInt(SMALL_ICON_COLOR_KEY);
 
         //Notification作成
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NCMBNotificationUtils.getDefaultChannel())
-                .setSmallIcon(icon)//通知エリアのアイコン設定
+        final String dataKey = "com.nifcloud.mbaas.Data";
+
+        if (pushData.getString(dataKey) != null) {
+            String imageUrl = null;
+            Bitmap bitmap = null;
+            try {
+                JSONObject userSettingJson = new JSONObject((String) pushData.get(dataKey));
+                if (userSettingJson.get("imgUrl") != null) {
+                    imageUrl = userSettingJson.get("imgUrl").toString();
+                }
+            } catch (JSONException e) {}
+
+            if (imageUrl != null && imageUrl.length() > 4 && Patterns.WEB_URL.matcher(imageUrl).matches()) {
+                bitmap = getBitmapFromURL(imageUrl);
+            }
+            if (bitmap != null) {
+                settingBigNotification(bitmap, notificationBuilder, icon, smallIconColor, title, message, pendingIntent, defaultSoundUri);
+            } else {
+                settingSmallNotification(notificationBuilder, icon, smallIconColor, title, message, pendingIntent, defaultSoundUri);
+            }
+        } else {
+            settingSmallNotification(notificationBuilder, icon, smallIconColor, title, message, pendingIntent, defaultSoundUri);
+        }
+
+        return notificationBuilder;
+    }
+
+    private void settingBigNotification(Bitmap bitmap, NotificationCompat.Builder notificationBuilder, int icon, int smallIconColor, String title, String message, PendingIntent pendingIntent, Uri defaultSoundUri) {
+        NotificationCompat.BigPictureStyle bigPictureStyle = new NotificationCompat.BigPictureStyle();
+        bigPictureStyle.setBigContentTitle(title);
+        bigPictureStyle.setSummaryText(message);
+        bigPictureStyle.bigPicture(bitmap).bigLargeIcon(null);
+
+        notificationBuilder.setSmallIcon(icon)//通知エリアのアイコン設定
+                .setColor(smallIconColor) //通知エリアのアイコンカラー設定
+                .setContentTitle(title)
+                .setContentText(message)
+                .setStyle(bigPictureStyle)
+                .setAutoCancel(true)//通知をタップしたら自動で削除する
+                .setSound(defaultSoundUri)//端末のデフォルトサウンド
+                .setContentIntent(pendingIntent);//通知をタップした際に起動するActivity
+    }
+
+    private void settingSmallNotification(NotificationCompat.Builder notificationBuilder, int icon, int smallIconColor, String title, String message, PendingIntent pendingIntent, Uri defaultSoundUri) {
+        notificationBuilder.setSmallIcon(icon)//通知エリアのアイコン設定
                 .setColor(smallIconColor) //通知エリアのアイコンカラー設定
                 .setContentTitle(title)
                 .setContentText(message)
@@ -227,8 +283,20 @@ public class NCMBFirebaseMessagingService extends FirebaseMessagingService {
                 .setAutoCancel(true)//通知をタップしたら自動で削除する
                 .setSound(defaultSoundUri)//端末のデフォルトサウンド
                 .setContentIntent(pendingIntent);//通知をタップした際に起動するActivity
+    }
 
-        return notificationBuilder;
+    private Bitmap getBitmapFromURL(String strURL) {
+        try {
+            URL url = new URL(strURL);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setDoInput(true);
+            connection.connect();
+            InputStream input = connection.getInputStream();
+            Bitmap myBitmap = BitmapFactory.decodeStream(input);
+            return myBitmap;
+        } catch (IOException e) {
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
## 概要(Summary)

- Fixed #243 

## 動作確認手順(Step for Confirmation)

1. Implement Android basic usage
https://mbaas.nifcloud.com/doc/current/push/basic_usage_android.html

2. Send push notification from [the management screen](https://mbaas.nifcloud.com/doc/current/push/basic_usage_android.html#%E3%83%97%E3%83%83%E3%82%B7%E3%83%A5%E9%80%9A%E7%9F%A5%E3%82%92%E9%80%81%E4%BF%A1%E3%81%99%E3%82%8B)

- Title: "Test push notification title"
- Message: "Test push notification message"
- User Setting Value (JSON):  {"imgUrl":"https://mbaas.nifcloud.com/images/home/img_type0106_l.png"}
**KEY**: imgUrl