### PR TITLE
関連のブランチの合流

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -52,3 +52,11 @@ jobs:
 
       - name: build and test Android SDK
         run: ./gradlew build test --continue --info
+
+      - name: makeJar
+        run: ./gradlew clean makeJar
+      - name: upload NCMB.jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: NCMB.jar
+          path: /home/runner/work/ncmb_android/release/NCMB.jar


### PR DESCRIPTION
- workflowに追加するNCMB.jarの生成に、ドキュメンテーションコメントの補完が必要なため合流します